### PR TITLE
Added VPC_Overlap tool to AWS utils

### DIFF
--- a/nrawling/AWS_Utils/VPC_overlap/Pipfile
+++ b/nrawling/AWS_Utils/VPC_overlap/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pycodestyle = "*"
+pydocstyle = "*"
+pylint = "*"
+
+[packages]
+boto3 = "*"
+click = "*"
+ipaddress = "*"
+

--- a/nrawling/AWS_Utils/VPC_overlap/README.md
+++ b/nrawling/AWS_Utils/VPC_overlap/README.md
@@ -1,0 +1,29 @@
+# VPC_overlap
+
+VPC_overlap is a tool for checking VPC network assignments across an
+AWS Organization for overlaps which could create obstacles to peering.
+
+## Supported functions
+
+All choices support a "--profile" option to use the profile for the master account.
+Only profiles for the master account in an AWS Organization are supported.
+
+Output format is CSV
+
+###compute-overlaps
+
+Compute and display VPC network overlaps.
+
+Returns a 
+
+###fetch-accounts
+
+Retrieve list of accounts in AWS Organizations.
+
+###fetch-regions
+
+Retrieve list of regions from EC2 service.
+
+###fetch-vpcs
+
+Retrieve VPCs for accounts.

--- a/nrawling/AWS_Utils/VPC_overlap/__init__.py
+++ b/nrawling/AWS_Utils/VPC_overlap/__init__.py
@@ -1,0 +1,1 @@
+"""vpc_overlaps script and modules. Check AWS VPCs for network overlaps."""

--- a/nrawling/AWS_Utils/VPC_overlap/accounts.py
+++ b/nrawling/AWS_Utils/VPC_overlap/accounts.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+"""Classes for AWS accounts."""
+
+# import boto3
+# from botocore.exceptions import ClientError
+
+
+class OrgAccount:
+    """Manage AWS Accounts from AWS Organizations."""
+
+    def __init__(self, SESSION):
+        """Create an OrgAccount object."""
+        self.session = SESSION
+        self.org = self.session.client('organizations')
+
+    def get_accounts(self):
+        """Get child accounts for current profile."""
+        return [{'AccountId': account['Id'], 'AccountName': account['Name']}
+                for account in self.org.list_accounts()['Accounts']]

--- a/nrawling/AWS_Utils/VPC_overlap/ec2.py
+++ b/nrawling/AWS_Utils/VPC_overlap/ec2.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+"""Classes for AWS EC2 resources."""
+
+import boto3
+# from botocore.exceptions import ClientError
+
+
+class ElasticComputeCloud:
+    """Retrieve information from AWS EC2."""
+
+    def __init__(self, sessionParameter, region='us-east-1'):
+        """Create an ElasticComputeCloud object."""
+        self.session = sessionParameter
+        self.ecc = self.session.client('ec2', region)
+
+    def get_regions(self):
+        """Get available regions for current profile."""
+        return [{'RegionName': region['RegionName']}
+                for region in self.ecc.describe_regions()['Regions']]
+
+    def get_vpcs(self):
+        """Get VPCs for current profile."""
+        return [{'VpcId': vpc['VpcId'], 'CidrBlock': vpc['CidrBlock']}
+                for vpc in self.ecc.describe_vpcs()['Vpcs']]
+
+    def get_all_vpcs(self, accounts):
+        """Get VPCs for all child accounts."""
+        vpcs = []
+
+        # Fetch regions once
+        regions = self.get_regions()
+
+        # For each account, check for VPCs in each region
+        for account in accounts:
+            # We will try to change the to Admin role of child accounts
+            # Should add a TRY block here
+            sts_client = boto3.client('sts')
+            assumed_role_object = sts_client.assume_role(
+                RoleArn="arn:aws:iam::"+account['AccountId']+":role/Admin",
+                RoleSessionName="AssumeRoleSession1")
+            credentials = assumed_role_object['Credentials']
+
+            account_session = boto3.Session(
+                aws_access_key_id=credentials['AccessKeyId'],
+                aws_secret_access_key=credentials['SecretAccessKey'],
+                aws_session_token=credentials['SessionToken'],
+            )
+
+            for region in regions:
+                loop_ecc = ElasticComputeCloud(
+                    account_session,
+                    region['RegionName'])
+                for vpc in loop_ecc.get_vpcs():
+                    vpc['AccountId'] = account['AccountId']
+                    vpc['AccountName'] = account['AccountName']
+                    vpc['Region'] = region['RegionName']
+                    vpcs.append(vpc)
+
+        return vpcs

--- a/nrawling/AWS_Utils/VPC_overlap/vpc_overlap.py
+++ b/nrawling/AWS_Utils/VPC_overlap/vpc_overlap.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""vpc_overlap: check an AWS Organization VPCs for address overlaps.
+
+vpc_overlap makes it easier to check for network overlaps across accounts.
+- Fetch AWS Account list from AWS Organizations
+- Fetch VPCs for each account, for each region
+- Check and report network overlaps
+"""
+
+import csv
+import ipaddress
+import sys
+
+import boto3
+import click
+
+from accounts import OrgAccount
+from ec2 import ElasticComputeCloud
+
+SESSION = None
+ORGACCOUNT = None
+
+
+def deliver_output(data):
+    """Use to process data output, currently CSV only."""
+    writer = csv.DictWriter(sys.stdout, fieldnames=data[0].keys())
+    writer.writeheader()
+    writer.writerows(data)
+
+
+@click.group()
+@click.option('--profile', default=None, help="Use a given AWS profile.")
+def cli(profile):
+    """vpc_overlap checks an AWS Organization VPCs for address overlaps."""
+    global SESSION, ORGACCOUNT
+
+    session_cfg = {}
+    if profile:
+        session_cfg['profile_name'] = profile
+
+    SESSION = boto3.Session(**session_cfg)
+    ORGACCOUNT = OrgAccount(SESSION)
+
+
+@cli.command('fetch-accounts')
+def fetch_accounts():
+    """Retrieve list of accounts in AWS Organizations."""
+    global ORGACCOUNT
+
+    deliver_output(ORGACCOUNT.get_accounts())
+
+
+@cli.command('fetch-regions')
+def fetch_regions():
+    """Retrieve list of regions from EC2 service."""
+    ecc = ElasticComputeCloud(SESSION)
+
+    deliver_output(ecc.get_regions())
+
+
+@cli.command('fetch-vpcs')
+def fetch_vpcs():
+    """Retrieve VPCs for accounts."""
+    global SESSION, ORGACCOUNT
+
+    accounts = ORGACCOUNT.get_accounts()
+    ecc = ElasticComputeCloud(SESSION)
+
+    deliver_output(ecc.get_all_vpcs(accounts))
+
+
+@cli.command('compute-overlaps')
+def compute_overlaps():
+    """Compute and display VPC network overlaps."""
+    global SESSION, ORGACCOUNT
+
+    accounts = ORGACCOUNT.get_accounts()
+    ecc = ElasticComputeCloud(SESSION)
+    vpcs = ecc.get_all_vpcs(accounts)
+
+    overlaps = []
+
+    # walk dict of vpcs looking for conflicts
+    # for vpc in vpcs:
+    for i, vpc in enumerate(vpcs):
+        net = ipaddress.IPv4Network(vpc['CidrBlock'])
+        # for vpc2 in vpcs:
+        for i2 in range(i + 1, len(vpcs)):
+            vpc2 = vpcs[i2]
+            if (vpc['VpcId'] != vpc2['VpcId']) and (
+                    net.overlaps(ipaddress.IPv4Network(vpc2['CidrBlock']))):
+                overlaps = overlaps + [{
+                    'FirstVpcAccountId': vpc['AccountId'],
+                    'FirstVpcAccountName': vpc['AccountName'],
+                    'FirstVpcRegion': vpc['Region'],
+                    'FirstVpcId': vpc['VpcId'],
+                    'FirstVpcCidr': vpc['CidrBlock'],
+                    'SecondVpcAccountId': vpc2['AccountId'],
+                    'SecondVpcAccountName': vpc2['AccountName'],
+                    'SecondVpcRegion': vpc2['Region'],
+                    'SecondVpcId': vpc2['VpcId'],
+                    'SecondVpcCidr': vpc2['CidrBlock']}]
+
+    deliver_output(overlaps)
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
Added a Python-based tool I built for internal use at by current place for checking all of the VPCs across all accounts and regions in an AWS Organization for CIDR overlaps.